### PR TITLE
Fix double forward slashes in term URLs

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,7 +5,7 @@
     {{ range .Data.Terms.Alphabetical }}
       <div class="terms">
         <h4 class="term-name" >
-          <a href="{{ .Page.Permalink }}/">{{ .Page.Title }}</a>
+          <a href="{{ .Page.Permalink }}">{{ .Page.Title }}</a>
           <span class="badge">{{ .Count }}</span>
         </h4>
       </div>


### PR DESCRIPTION
This fixes double forward slashes in term URLs. Example: `/categories/themes//`