### PR TITLE
Makes [summary] independant from [truncate] variable

### DIFF
--- a/layouts/partials/preview.html
+++ b/layouts/partials/preview.html
@@ -3,8 +3,10 @@
       <h2 class="post-title">{{ .Title }}</h2>
   </a>
   <div class="post-entry">
-    {{ if .Truncated }}
+    {{ if .Summary }}
       <p>{{ .Summary }}</p>
+    {{ end }}
+    {{ if .Truncated }}
         <a href="{{ .Permalink }}" class="post-read-more">{{ i18n "read-more" }}</a>
     {{ end }}
   </div>


### PR DESCRIPTION
As a post can also have a custom summary, it might make more sense to have a separated condition to show/hide a post summary from the page.