### PR TITLE
Speedup of theme mode loading

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,11 +11,21 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <link rel="alternate" type="application/rss+xml" href="{{ .Site.BaseURL }}index.xml" title="{{ .Site.Title }}">
 <!-- Stylesheets -->
-<link id="dark-mode-theme" rel="stylesheet" href="{{ .Site.BaseURL }}css/dark.css" />
 <link rel="stylesheet" href="{{ .Site.BaseURL }}fontawesome/css/all.min.css" />
 {{ range .Site.Params.customCSS }}
 <link rel="stylesheet" href="{{ . | absURL }}" />
 {{ end }}
+<link id="dark-mode-theme" rel="stylesheet" href="{{ .Site.BaseURL }}css/dark.css" />
+<!-- Load theme mode from browser cache -->
+<script>
+	var darkTheme = document.getElementById("dark-mode-theme");
+	var storedTheme = localStorage.getItem("dark-mode-storage");
+	if ( storedTheme === "dark") {
+		darkTheme.disabled = false;
+    } else if (storedTheme === "light") {
+		darkTheme.disabled = true;
+    }
+</script>
 <!-- script -->
 <script src="{{ .Site.BaseURL }}js/bundle.js"></script>
 <script src="{{ .Site.BaseURL }}js/instantpage.min.js" type="module" defer></script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,13 +18,13 @@
 <link id="dark-mode-theme" rel="stylesheet" href="{{ .Site.BaseURL }}css/dark.css" />
 <!-- Load theme mode from browser cache -->
 <script>
-	var darkTheme = document.getElementById("dark-mode-theme");
-	var storedTheme = localStorage.getItem("dark-mode-storage");
-	if ( storedTheme === "dark") {
-		darkTheme.disabled = false;
-    } else if (storedTheme === "light") {
-		darkTheme.disabled = true;
-    }
+var darkTheme = document.getElementById("dark-mode-theme");
+var storedTheme = localStorage.getItem("dark-mode-storage");
+if (storedTheme === "dark") {
+    darkTheme.disabled = false;
+} else if (storedTheme === "light") {
+    darkTheme.disabled = true;
+}
 </script>
 <!-- script -->
 <script src="{{ .Site.BaseURL }}js/bundle.js"></script>


### PR DESCRIPTION
By default the dark theme was rendered. After the complete page was loaded the theme was switched according the stored value. This cause a flicker (background was first black for a second (until the page was completely loaded) and then turned white.

This commit moves the loading of the theme mode to the beginning (into the <head> section). Therefore the correct mode gets rendered.