### PR TITLE
Add Matomo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simple and minimal personal blog theme for [Hugo](https://gohugo.io/).
 ## Features
 
 - Support tags, categories and archives
-- Analytics integration (Google or Goatcounter)
+- Analytics integration (Google, Goatcounter or Matomo)
 - Responsive
 - Dark mode
 - Syntax Highlight (see [Hugo doc](https://gohugo.io/content-management/syntax-highlighting/))
@@ -58,6 +58,10 @@ disqusShortName = "yourdisqusshortname"
 
 [params.goatcounter]
   domain="stats.domain.com"
+
+[params.matomo]
+  domain="stats.domain.com"
+  id="123"
 
 [Author]
   name = "Hugo Author"

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -15,3 +15,22 @@
   <script data-goatcounter="https://{{ $domain }}/count"
           async src="//{{ $domain }}/count.js"></script>
 {{ end }}
+{{ if and (.Site.Params.matomo) ( not .Site.IsServer ) }}
+  {{ $domain := .Site.Params.matomo.domain }}
+  {{ $id := .Site.Params.matomo.id }}
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+      var u="//{{ $domain }}/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '{{ $id }}']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+{{ end }}


### PR DESCRIPTION
Hello!

First of all thank you for Harbor! I love its clean design, and multi language support.
As for tracking I want to use Matomo (previously Piwik) I did those changes:

 * Add Matomo tracking code block the analytics partial beside
 * Update the readme so users are aware of this feature as well

With best regards
Pavel