### PR TITLE
Improve search performance when there are many search results

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -69,26 +69,18 @@ const renderResults = (results) => {
     self.findIndex(e => e.id === element.id) === index)
 
   let instance = new Mark(document.querySelector('#searchResults'))
-  arr.forEach((result) => {
-    let resultPage = document.createElement('div')
-    resultPage.className = 'searchResultPage'
+  let elements = arr.map((result) => {
+    const matchPos = result.doc.body.indexOf(query)
+    const bodyStartPos = matchPos - BODY_LENGTH / 2 > 0 ? matchPos - BODY_LENGTH / 2 : 0
+    const body = result.doc.body.substr(bodyStartPos, BODY_LENGTH)
 
-    let resultTitle = document.createElement('a')
-    resultTitle.className = 'searchResultTitle'
-    resultTitle.href = result.doc.href
-    resultTitle.innerHTML = result.doc.title
-    resultPage.append(resultTitle)
-
-    let resultBody = document.createElement('div')
-    resultBody.className = 'searchResultBody'
-    let matchPos = result.doc.body.indexOf(query)
-    let bodyStartPos = matchPos - BODY_LENGTH / 2 > 0 ? matchPos - BODY_LENGTH / 2 : 0
-    resultBody.innerHTML = result.doc.body.substr(bodyStartPos, BODY_LENGTH)
-    resultPage.append(resultBody)
-    searchResults.append(resultPage)
-
-    instance.mark(query)
+    return `<div class="searchResultPage">
+        <a class="searchResultTitle" href="${result.doc.href}">${result.doc.title}</a>
+        <div class="searchResultBody">${body}</div>
+      </div>`
   })
+  searchResults.innerHTML = elements.join('');
+  instance.mark(query)
 }
 
 init();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -69,17 +69,26 @@ const renderResults = (results) => {
     self.findIndex(e => e.id === element.id) === index)
 
   let instance = new Mark(document.querySelector('#searchResults'))
-  let elements = arr.map((result) => {
-    const matchPos = result.doc.body.indexOf(query)
-    const bodyStartPos = matchPos - BODY_LENGTH / 2 > 0 ? matchPos - BODY_LENGTH / 2 : 0
-    const body = result.doc.body.substr(bodyStartPos, BODY_LENGTH)
+  let fragment = document.createDocumentFragment();
+  arr.forEach((result) => {
+    let resultPage = document.createElement('div')
+    resultPage.className = 'searchResultPage'
 
-    return `<div class="searchResultPage">
-        <a class="searchResultTitle" href="${result.doc.href}">${result.doc.title}</a>
-        <div class="searchResultBody">${body}</div>
-      </div>`
+    let resultTitle = document.createElement('a')
+    resultTitle.className = 'searchResultTitle'
+    resultTitle.href = result.doc.href
+    resultTitle.innerHTML = result.doc.title
+    resultPage.append(resultTitle)
+
+    let resultBody = document.createElement('div')
+    resultBody.className = 'searchResultBody'
+    let matchPos = result.doc.body.indexOf(query)
+    let bodyStartPos = matchPos - BODY_LENGTH / 2 > 0 ? matchPos - BODY_LENGTH / 2 : 0
+    resultBody.innerHTML = result.doc.body.substr(bodyStartPos, BODY_LENGTH)
+    resultPage.append(resultBody)
+    fragment.append(resultPage)
   })
-  searchResults.innerHTML = elements.join('');
+  searchResults.append(fragment);
   instance.mark(query)
 }
 


### PR DESCRIPTION
# Issue

When there are many search results, searching is very slow.

In the case of the following, searching freezes the page for nearly 20 seconds.
* **Size of `search-data.json`**: 1.1MB
* **Number of blog entries**: 128
* **Number of search results**: 98

https://github.com/matsuyoshi30/harbor/assets/1453749/86281056-82ae-4855-9b35-354cac038a44

# Fixes

Since the issue is caused by the way to append html element, this PR fix it. With this fix, performance in the same situation is improved.

https://github.com/matsuyoshi30/harbor/assets/1453749/7a7e03a6-4198-4efa-9712-7bce4a8f779a



